### PR TITLE
Added Oppressor MK2 primitive autopilot, also added Oppressor MK2 spawning hotkey

### DIFF
--- a/gta5.ahk
+++ b/gta5.ahk
@@ -77,6 +77,7 @@ Numpad4:: ; Apply ceo armor
 	Sleep, 250		; Extra long sleep just to make sure the menu has time to appear properly.
 	Gosub, Down
 	Gosub, Down
+	Gosub, Down
 	Gosub, Enter
 	Gosub, Down
 	Gosub, Enter
@@ -91,6 +92,7 @@ return
 Numpad5:: ; open ceo snack
 	Gosub, Menu
 	Sleep, 250
+	Gosub, Down
 	Gosub, Down
 	Gosub, Down
 	Gosub, Enter
@@ -119,11 +121,14 @@ return
 NumpadSub:: ; ceo oppressor mk2 spawn!
 	Gosub, Menu
 	Sleep, 250
-    Gosub, Down
+    	Gosub, Down
 	Gosub, Down
 	Gosub, Down
 	Gosub, Down
 	Gosub, Down
+	Gosub, Down
+	Gosub, Enter ; Enter services
+	Gosub, Up
 	Gosub, Enter ; Enter terrorbyte menu
 	Gosub, Down
 	Gosub, Down
@@ -134,6 +139,7 @@ return
 Numpad1:: ; Apply normal armor
 	Gosub, Menu
 	Sleep, 250		; Extra long sleep just to make sure the menu has time to appear properly.
+	Gosub, Down
 	Gosub, Down
 	Gosub, Enter
 	Gosub, Down
@@ -149,6 +155,7 @@ return
 Numpad2:: ; Eat a normal snack. This will cycle through them as they run out.
 	Gosub, Menu
 	Sleep, 250
+	Gosub, Down
 	Gosub, Down
 	Gosub, Enter
 	Gosub, Down

--- a/gta5.ahk
+++ b/gta5.ahk
@@ -215,7 +215,7 @@ Numpad8:: ; Auto-outfit an X80 Proto export vehicle
 	Gosub, Enter
 return
 
-Numpad7:: ; Test auto-mk2 speed fly straight
+Numpad7:: ; Autopilot to fly straight on oppressor mk2, use another button to stop autopilot
 	Send {W down}
 	Send {Space down}
 	BreakLoop = 0
@@ -225,11 +225,11 @@ Numpad7:: ; Test auto-mk2 speed fly straight
 		Send {9 down}
 		Sleep, 125
 		Send {9 up}
-		Sleep, 335
+		Sleep, 300
 	}
 return
 
-NumpadDiv:: ; Stop test auto-mk2 speed fly straight
+NumpadDiv:: ; How to stop oppressor mk2 autopilot
 	Send {W up}
 	Send {Space up}
 	BreakLoop = 1

--- a/gta5.ahk
+++ b/gta5.ahk
@@ -215,4 +215,22 @@ Numpad8:: ; Auto-outfit an X80 Proto export vehicle
 	Gosub, Enter
 return
 
-#IfWinActive
+Numpad7:: ; Test auto-mk2 speed fly straight
+	Send {W down}
+	Send {Space down}
+	BreakLoop = 0
+	Loop {
+		if (BreakLoop = 1)
+			break
+		Send {9 down}
+		Sleep, 125
+		Send {9 up}
+		Sleep, 335
+	}
+return
+
+NumpadDiv:: ; Stop test auto-mk2 speed fly straight
+	Send {W up}
+	Send {Space up}
+	BreakLoop = 1
+return

--- a/gta5.ahk
+++ b/gta5.ahk
@@ -116,6 +116,21 @@ NumpadAdd:: ; ceo buzzard spawn!
 	Gosub, Enter
 return
 
+NumpadSub:: ; ceo oppressor mk2 spawn!
+	Gosub, Menu
+	Sleep, 250
+    Gosub, Down
+	Gosub, Down
+	Gosub, Down
+	Gosub, Down
+	Gosub, Down
+	Gosub, Enter ; Enter terrorbyte menu
+	Gosub, Down
+	Gosub, Down
+	Gosub, Enter ; Spawn opressor mk2 near you if no other personal vehicle and in public lobby
+    Gosub, Menu
+return
+
 Numpad1:: ; Apply normal armor
 	Gosub, Menu
 	Sleep, 250		; Extra long sleep just to make sure the menu has time to appear properly.


### PR DESCRIPTION
Check commit messages on how to use.

To spawn an Oppressor MK2, make sure you are CEO/MC with the (M)enu closed, press NumpadMinus and if available your bike will spawn right next to you!